### PR TITLE
zsh p10k: Use non-breaking space as prompt end separator

### DIFF
--- a/home/dot_p10k.zsh
+++ b/home/dot_p10k.zsh
@@ -1490,6 +1490,15 @@
     p10k segment -f 2 -t "$HOST"
   }
 
+  function p10k-on-post-prompt() {
+    p10k display '1/left/*'=hide
+    p10k display '1/right/*'=hide
+  }
+  function p10k-on-pre-prompt() {
+    p10k display '1/left/*'=show
+    p10k display '2/left/*'=show
+  }
+
   # Use a non-breaking space which we can search for to find the previous command
   # execution.
   typeset -g POWERLEVEL9K_LEFT_SEGMENT_END_SEPARATOR=$'\u00a0'
@@ -1524,7 +1533,7 @@
   #   - always:   Trim down prompt when accepting a command line.
   #   - same-dir: Trim down prompt when accepting a command line unless this is the first command
   #               typed after changing current working directory.
-  typeset -g POWERLEVEL9K_TRANSIENT_PROMPT=always
+  typeset -g POWERLEVEL9K_TRANSIENT_PROMPT=off # custom transient in pre/post-prompt funcs.
 
   # Instant prompt mode.
   #

--- a/home/dot_p10k.zsh
+++ b/home/dot_p10k.zsh
@@ -134,7 +134,9 @@
   typeset -g POWERLEVEL9K_ICON_BEFORE_CONTENT=true
 
   # Add an empty line before each prompt.
-  typeset -g POWERLEVEL9K_PROMPT_ADD_NEWLINE=true
+  # Ideally we'd enable new line before the prompt, but this also spreads out
+  # the historical commands too much (2 additiona blank lines), so disable it.
+  typeset -g POWERLEVEL9K_PROMPT_ADD_NEWLINE=false
 
   # Connect left prompt lines with these symbols.
   typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX=

--- a/home/dot_p10k.zsh
+++ b/home/dot_p10k.zsh
@@ -1490,6 +1490,10 @@
     p10k segment -f 2 -t "$HOST"
   }
 
+  # Use a non-breaking space which we can search for to find the previous command
+  # execution.
+  typeset -g POWERLEVEL9K_LEFT_SEGMENT_END_SEPARATOR=$'\u00a0'
+
   # User-defined prompt segments may optionally provide an instant_prompt_* function. Its job
   # is to generate the prompt segment for display in instant prompt. See
   # https://github.com/romkatv/powerlevel10k/blob/master/README.md#instant-prompt.


### PR DESCRIPTION
Inspired by [tmux prompt navigation](https://www.youtube.com/watch?v=uglorjY0Ntg) (also referenced in https://github.com/salcode/ironcode-tmux/issues/21).

Using a non-breaking space in the prompt gives us a reliable way to find the previous prompt compared to looking for a more generic "> " which is more likely to be printed in the output of a command, but also matches the continuation prompt.

Ideally, this would be as simple as setting `POWERLEVEL9K_LEFT_SEGMENT_END_SEPARATOR`, but unfortunately that breaks transient prompt which always seems to use a blank space. Since all previous prompts are transient prompts, that defeats the purpose -- so we end up disabling transient prompt, but emulating it using p10k's pre-prompt/post-prompt hooks. See https://github.com/romkatv/powerlevel10k/issues/1905#issuecomment-1159813172 used as a starting point.

The emulation leads to more blank lines than we'd like, so this change also disables the additional newline from `POWERLEVEL9K_PROMPT_ADD_NEWLINE`.