### PR TITLE
Migrate to zoxide

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -27,6 +27,7 @@ yq = "4"
 
 # Other
 tmux-fastcopy = "0.14.1"
+zoxide = "0.9"
 
 [tool_alias]
 gs = "ubi:abhinav/git-spice[exe=gs]"

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -52,26 +52,6 @@ zstyle ':fzf-tab:complete:vim:*' fzf-preview 'cat $realpath'
 
 export GITHUB_USER=prashantv
 
-function jg() {
-  if [ -d $GOPATH/src/github.com/prashantv/$1 ]; then
-    cd $GOPATH/src/github.com/prashantv/$1
-    return
-  fi
-  if [ -d $GOPATH/src/$1 ]; then
-    cd $GOPATH/src/$1
-    return
-  fi
-
-  # Try every directory in $GOPATH to see if there's a match.
-  for f in $(echo $GOPATH/src/*); do
-    if [ -d $f/$1 ]; then
-      cd $f/$1
-      return
-    fi
-  done
-  echo "Failed to find match in $GOPATH for $1"
-}
-
 refresh_tmux_env() {
   for key in DISPLAY SSH_AUTH_SOCK SSH_CONNECTION SSH_CLIENT; do
     if (tmux show-environment | grep "^${key}" > /dev/null); then
@@ -98,10 +78,10 @@ eval "$(mise activate)"
 
 # Aliases
 
-# fasd with autojump aliases
-eval "$(fasd --init auto)"
-alias j='fasd_cd -d'     # cd, same functionality as j in autojump
-alias jj='fasd_cd -d -i' # cd with interactive selection
+# zoxide (directory jumping by frecency)
+eval "$(zoxide init zsh)"
+alias j=z
+alias jj=zi
 
 # vim quit
 alias ':q'=exit

--- a/setup.sh
+++ b/setup.sh
@@ -187,14 +187,18 @@ else
   echo "  direnv already installed"
 fi
 
-# fasd
-if [ ! -f "$HOME/bin/fasd" ]; then
-  echo "  Downloading fasd..."
-  mkdir -p "$HOME/bin"
-  curl -fsSL "https://raw.githubusercontent.com/clvv/fasd/master/fasd" -o "$HOME/bin/fasd"
-  chmod +x "$HOME/bin/fasd"
-else
-  echo "  fasd already installed"
+# zoxide — one-time import from fasd/autojump if zoxide db is empty
+zoxide_db="${XDG_DATA_HOME:-$HOME/.local/share}/zoxide/db.zo"
+if [ ! -f "$zoxide_db" ] || [ ! -s "$zoxide_db" ]; then
+  autojump_db="$HOME/.local/share/autojump/autojump.txt"
+  fasd_db="$HOME/.fasd"
+  if [ -s "$autojump_db" ]; then
+    echo "  Importing autojump database into zoxide..."
+    mise exec -- zoxide import --from=autojump "$autojump_db"
+  elif [ -s "$fasd_db" ]; then
+    echo "  Importing fasd database into zoxide..."
+    mise exec -- zoxide import --from=z "$fasd_db"
+  fi
 fi
 
 # fzf-git
@@ -213,7 +217,7 @@ if ! command -v mise >/dev/null 2>&1; then
 fi
 export PATH="$HOME/.local/bin:$PATH"
 echo "  Running mise install for shell dependencies"
-mise install fzf
+mise install fzf zoxide
 
 # --- Misc setup ---
 


### PR DESCRIPTION
* setup.sh: Add one-time import from fasd/z based on discovered databases
* Keep support for `j`/`jj` aliases

Tangentially related: remove `jg` alias which is no longer used.